### PR TITLE
ratings: Load More style tweak

### DIFF
--- a/src/components/organisms/RatingList.res
+++ b/src/components/organisms/RatingList.res
@@ -172,7 +172,7 @@ let make = (~ratings) => {
       ? {
           pageInfo.endCursor
           ->Option.map(endCursor => {
-            <Link to={"./" ++ "?after=" ++ encodeURIComponent(endCursor)}> {t`Load more players...`} </Link>
+            <Link className="block py-4" to={"./" ++ "?after=" ++ encodeURIComponent(endCursor)}> {t`Load more players...`} </Link>
           }
           )
           ->Option.getOr(React.null)


### PR DESCRIPTION
# Context

I was scrolling the Rankings view, and tried to click the *Load more players...* link at the bottom of the page. Unfortunately I kept fat-fingering, and clicking the last user profile in the list, instead of the intended link.

# Changes

This PR adds a little vertical breathing room to the *Load more players link* (and renders the `a` as a `block` element) to increase the interaction target size.

## Before

![image](https://github.com/user-attachments/assets/92bca22c-c09c-49ad-9de8-527430ead2e8)

## After

![image](https://github.com/user-attachments/assets/a5b6ae3e-14ea-4de5-9bf9-d6cd9e5cd082)


